### PR TITLE
fix(Interactables): update Interactables namespace to latest

### DIFF
--- a/Runtime/SharedResources/Scripts/ActivationValidator.cs
+++ b/Runtime/SharedResources/Scripts/ActivationValidator.cs
@@ -4,7 +4,7 @@
     using Malimbe.XmlDocumentationAttribute;
     using System;
     using System.Collections.Generic;
-    using Tilia.Interactions.Interactables;
+    using Tilia.Interactions.Interactables.Interactables;
     using UnityEngine;
     using UnityEngine.Events;
     using Zinnia.Data.Attribute;

--- a/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
@@ -2,8 +2,8 @@
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
-    using Tilia.Interactions.Interactables;
-    using Tilia.Interactions.Interactables.Grab;
+    using Tilia.Interactions.Interactables.Interactables;
+    using Tilia.Interactions.Interactables.Interactables.Grab;
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Collection.List;

--- a/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
@@ -5,7 +5,7 @@
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
     using System;
-    using Tilia.Interactions.Interactables;
+    using Tilia.Interactions.Interactables.Interactables;
     using UnityEngine;
     using UnityEngine.Events;
     using Zinnia.Data.Attribute;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "io.extendreality.zinnia.unity": "1.19.0",
         "io.extendreality.tilia.utilities.shaders.unity": "1.1.0",
         "io.extendreality.tilia.mutators.objectfollower.unity": "1.1.2",
-        "io.extendreality.tilia.interactions.interactables.unity": "1.8.1"
+        "io.extendreality.tilia.interactions.interactables.unity": "1.9.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The Interactables namespace changed in version 1.9.0 of the
Interactables package, so it has been updated accordingly.