### PR TITLE
fix(prefabs): apply slight position offset on force snap - fixes #84

### DIFF
--- a/Documentation/API/SnapZoneConfigurator.md
+++ b/Documentation/API/SnapZoneConfigurator.md
@@ -11,6 +11,7 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [ActivationArea]
   * [ActivationValidator]
   * [CollidingObjectsList]
+  * [DestinationLocation]
   * [Facade]
   * [ForceUnsnapInteractableProcess]
   * [GrabStateEmitter]
@@ -83,6 +84,16 @@ The GameObjectObservableList containing the list of objects that are currently c
 
 ```
 public GameObjectObservableList CollidingObjectsList { get; protected set; }
+```
+
+#### DestinationLocation
+
+The GameObject that determines the snap destination location.
+
+##### Declaration
+
+```
+public GameObject DestinationLocation { get; protected set; }
 ```
 
 #### Facade
@@ -368,6 +379,7 @@ public virtual void Unsnap()
 [ActivationArea]: #ActivationArea
 [ActivationValidator]: #ActivationValidator
 [CollidingObjectsList]: #CollidingObjectsList
+[DestinationLocation]: #DestinationLocation
 [Facade]: #Facade
 [ForceUnsnapInteractableProcess]: #ForceUnsnapInteractableProcess
 [GrabStateEmitter]: #GrabStateEmitter

--- a/Runtime/Prefabs/Interactions.SnapZone.prefab
+++ b/Runtime/Prefabs/Interactions.SnapZone.prefab
@@ -5335,6 +5335,7 @@ MonoBehaviour:
   snappedInteractablesList: {fileID: 8407923665559923119}
   snapDroppedInteractableProcess: {fileID: 8407923664943525174}
   forceUnsnapInteractableProcess: {fileID: 8407923664429067986}
+  destinationLocation: {fileID: 8407923664650951421}
 --- !u!1 &8407923666129015629
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
@@ -88,6 +88,12 @@
         [Serialized]
         [field: DocumentedByXml, Restricted]
         public GameObjectEventProxyEmitter ForceUnsnapInteractableProcess { get; protected set; }
+        /// <summary>
+        /// The <see cref="GameObject"/> that determines the snap destination location.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, Restricted]
+        public GameObject DestinationLocation { get; protected set; }
         #endregion
 
         /// <summary>
@@ -98,6 +104,11 @@
         /// Returns the currently snapped <see cref="GameObject"/>.
         /// </summary>
         public GameObject SnappedInteractable => SnappedInteractablesList.NonSubscribableElements.Count > 0 ? SnappedInteractablesList.NonSubscribableElements[0] : null;
+
+        /// <summary>
+        /// An offset to apply upon snap if the snapped <see cref="GameObject"/> is in the same position as the <see cref="DestinationLocation"/> to ensure the follower works correctly.
+        /// </summary>
+        private const float InitialOffset = 0.05f;
 
         /// <summary>
         /// Attempts to snap a given <see cref="GameObject"/> to the snap zone.
@@ -122,6 +133,11 @@
 
                 activatingZone.Facade.Unsnap();
                 break;
+            }
+
+            if (objectToSnap.transform.position.ApproxEquals(DestinationLocation.transform.position))
+            {
+                objectToSnap.transform.position += Vector3.forward * InitialOffset;
             }
 
             SnapDroppedInteractableProcess.Receive(objectToSnap);


### PR DESCRIPTION
There's an issue where if the GameObject being snapped and the
SnapZone are in the same location then a force snap is called then
the internal Object Follower won't think the position has changed
initially so will not perform the follow. This fix just applies
a slight position offset to the object being snapped just before
it is force snapped so this discrepancy is not an issue.