### PR TITLE
fix(SnapZoneConfigurator): apply snap validity rule to Snap method

### DIFF
--- a/Runtime/Prefabs/Interactions.SnapZone.prefab
+++ b/Runtime/Prefabs/Interactions.SnapZone.prefab
@@ -920,6 +920,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 098fc6c54c3792e49837be0f531aa588, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Rule.Collection.RuleContainerObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -1135,6 +1140,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -1841,6 +1851,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3b20687ab7424fdb9831faad0eef53ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  processCollisionsWhenDisabled: 1
   emittedTypes: -1
   statesToProcess: -1
   forwardingSourceValidity:
@@ -2546,6 +2557,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 45641bb26f54b8d4797b08b74c29645c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.BehaviourObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -3157,6 +3173,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -3990,6 +4011,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -5231,6 +5257,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7d01a890104495a49a7a72c5733174ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.SerializableTypeComponentObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -5326,6 +5357,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   facade: {fileID: 8407923665924606686}
   validCollisionRules: {fileID: 8407923664469734249}
+  allValidRules: {fileID: 8407923666129015626}
   grabStateEmitter: {fileID: 8407923665937188163}
   activationArea: {fileID: 8407923664845045255}
   activationValidator: {fileID: 8407923664688261256}

--- a/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
@@ -10,6 +10,7 @@
     using Zinnia.Data.Type;
     using Zinnia.Event.Proxy;
     using Zinnia.Extension;
+    using Zinnia.Rule;
     using Zinnia.Rule.Collection;
     using Zinnia.Tracking.Modification;
 
@@ -34,6 +35,12 @@
         [Serialized]
         [field: Header("Reference Settings"), DocumentedByXml]
         public RuleContainerObservableList ValidCollisionRules { get; protected set; }
+        /// <summary>
+        /// The <see cref="AllRule"/> that takes the <see cref="ValidCollisionRules"/>.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public AllRule AllValidRules { get; protected set; }
         /// <summary>
         /// The <see cref="InteractableGrabStateEmitter"/> that processes if the interactable entering the zone is being grabbed.
         /// </summary>
@@ -116,6 +123,11 @@
         /// <param name="objectToSnap">The object to attempt to snap.</param>
         public virtual void Snap(GameObject objectToSnap)
         {
+            if (!AllValidRules.Accepts(objectToSnap))
+            {
+                return;
+            }
+
             InteractableFacade snappableInteractable = objectToSnap.TryGetComponent<InteractableFacade>(true, true);
             if (snappableInteractable == null || SnappedInteractable != null)
             {


### PR DESCRIPTION
The Snap Validity rule on the facade was not being applied to when
the `Snap` method was being called, meaning things could still be
snapped when they should have been denied by a rule.

This fixes it by wrapping the Snap code with the rule check.