### PR TITLE
feat(SnapZoneManager): add component to manage scene snap zones

### DIFF
--- a/Runtime/SharedResources/Scripts/SnapZoneManager.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneManager.cs
@@ -1,0 +1,67 @@
+﻿namespace Tilia.Interactions.SnapZone
+{
+    using Tilia.Interactions.Interactables.Interactables;
+    using UnityEngine;
+    using Zinnia.Extension;
+
+    /// <summary>
+    /// A helper class for managing scene snap zones.
+    /// </summary>
+    public class SnapZoneManager : MonoBehaviour
+    {
+        /// <summary>
+        /// Determines if the given Interactable is in a Snap Zone and optionally returns the Snap Zone if it is one.
+        /// </summary>
+        /// <param name="interactable">The Interactable to search on.</param>
+        /// <param name="snapZoneFacade">The found Snap Zone to return.</param>
+        /// <returns>Whether the given Interactable is in a Snap Zone.</returns>
+        public virtual bool IsInSnapZone(InteractableFacade interactable, out SnapZoneFacade snapZoneFacade)
+        {
+            snapZoneFacade = null;
+
+            if (interactable == null)
+            {
+                return false;
+            }
+
+            foreach (GameObject activeCollision in interactable.Configuration.ActiveCollisions.NonSubscribableElements)
+            {
+                SnapZoneActivator foundActivator = activeCollision.TryGetComponent<SnapZoneActivator>();
+                if (foundActivator != null && foundActivator.Facade != null)
+                {
+                    snapZoneFacade = foundActivator.Facade;
+                    break;
+                }
+            }
+
+            return snapZoneFacade != null;
+        }
+
+        /// <summary>
+        /// Determines if the given Interactable is in a Snap Zone.
+        /// </summary>
+        /// <param name="interactable">The Interactable to search on.</param>
+        /// <returns>Whether the given Interactable is in a Snap Zone.</returns>
+        public virtual bool IsInSnapZone(InteractableFacade interactable)
+        {
+            return IsInSnapZone(interactable, out SnapZoneFacade _);
+        }
+
+        /// <summary>
+        /// Attempts to unsnap the given Interactable if it is snapped into a snap zone.
+        /// </summary>
+        /// <param name="interactable">The Interactable to attempt to unsnap.</param>
+        public virtual void UnsnapInteractable(InteractableFacade interactable)
+        {
+            if (!IsInSnapZone(interactable, out SnapZoneFacade foundSnapZone))
+            {
+                return;
+            }
+
+            if (foundSnapZone != null)
+            {
+                foundSnapZone.Unsnap();
+            }
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/SnapZoneManager.cs.meta
+++ b/Runtime/SharedResources/Scripts/SnapZoneManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56f4417741ec6d94c9cce699b70d4815
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The SnapZoneManager component provides an easy way to manage
scene snap zones. This first release only has a couple of useful
methods, one to determine if a given Interactable is in a SnapZone
(and optionally return the snap zone it is in), and to unsnap
an Interactable from a SnapZone when only the Interactable is
known.