### PR TITLE
feat(Facade): add ability to snap a default interactable on zone enable

### DIFF
--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -26,6 +26,10 @@ The public interface into the Interactions SnapZone Prefab.
 
 Defines the event with the GameObject.
 
+#### [SnapZoneManager]
+
+A helper class for managing scene snap zones.
+
 ### Structs
 
 #### [ActivationValidator.ListenerKey]
@@ -44,5 +48,6 @@ The state the SnapZone is in.
 [SnapZoneConfigurator]: SnapZoneConfigurator.md
 [SnapZoneFacade]: SnapZoneFacade.md
 [SnapZoneFacade.UnityEvent]: SnapZoneFacade.UnityEvent.md
+[SnapZoneManager]: SnapZoneManager.md
 [ActivationValidator.ListenerKey]: ActivationValidator.ListenerKey.md
 [SnapZoneFacade.SnapZoneState]: SnapZoneFacade.SnapZoneState.md

--- a/Documentation/API/SnapZoneConfigurator.md
+++ b/Documentation/API/SnapZoneConfigurator.md
@@ -7,14 +7,19 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [EndOfFrameInstruction]
+  * [SnapDefaultInteractableRoutine]
 * [Properties]
   * [ActivationArea]
   * [ActivationValidator]
+  * [AllValidRules]
   * [CollidingObjectsList]
   * [DestinationLocation]
   * [Facade]
   * [ForceUnsnapInteractableProcess]
   * [GrabStateEmitter]
+  * [InitialTransitionDuration]
   * [PropertyApplier]
   * [SnapDroppedInteractableProcess]
   * [SnappableInteractables]
@@ -35,6 +40,7 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [OnEnable()]
   * [ProcessOtherSnappablesOnSnap()]
   * [Snap(GameObject)]
+  * [SnapInitialAtEndOfFrame()]
   * [Unsnap()]
 
 ## Details
@@ -52,6 +58,28 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
 
 ```
 public class SnapZoneConfigurator : MonoBehaviour
+```
+
+### Fields
+
+#### EndOfFrameInstruction
+
+An instruction for yielding at the end of the current frame.
+
+##### Declaration
+
+```
+protected YieldInstruction EndOfFrameInstruction
+```
+
+#### SnapDefaultInteractableRoutine
+
+The Coroutine for managing the default initial snap.
+
+##### Declaration
+
+```
+protected Coroutine SnapDefaultInteractableRoutine
 ```
 
 ### Properties
@@ -74,6 +102,16 @@ The [ActivationValidator] that determines if the activation of the zone is valid
 
 ```
 public ActivationValidator ActivationValidator { get; protected set; }
+```
+
+#### AllValidRules
+
+The AllRule that takes the [ValidCollisionRules].
+
+##### Declaration
+
+```
+public AllRule AllValidRules { get; protected set; }
 ```
 
 #### CollidingObjectsList
@@ -124,6 +162,16 @@ The InteractableGrabStateEmitter that processes if the interactable entering the
 
 ```
 public InteractableGrabStateEmitter GrabStateEmitter { get; protected set; }
+```
+
+#### InitialTransitionDuration
+
+The initial duration to transition the default Interactable to the SnapZone.
+
+##### Declaration
+
+```
+public float InitialTransitionDuration { get; set; }
 ```
 
 #### PropertyApplier
@@ -356,6 +404,22 @@ public virtual void Snap(GameObject objectToSnap)
 | --- | --- | --- |
 | GameObject | objectToSnap | The object to attempt to snap. |
 
+#### SnapInitialAtEndOfFrame()
+
+Snaps the Facade.SnapInitialAtEndOfFrame to the snap zone at the end of the frame.
+
+##### Declaration
+
+```
+protected virtual IEnumerator SnapInitialAtEndOfFrame()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Collections.IEnumerator | An Enumerator to manage the running of the Coroutine. |
+
 #### Unsnap()
 
 Attempts to unsnap any existing InteractableFacade that is currently snapped to the snap zone.
@@ -371,18 +435,24 @@ public virtual void Unsnap()
 [SnapZoneActivator]: SnapZoneActivator.md
 [ActivationValidator]: SnapZoneConfigurator.md#ActivationValidator
 [ActivationValidator]: ActivationValidator.md
+[ValidCollisionRules]: SnapZoneConfigurator.md#ValidCollisionRules
 [SnapZoneFacade]: SnapZoneFacade.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[EndOfFrameInstruction]: #EndOfFrameInstruction
+[SnapDefaultInteractableRoutine]: #SnapDefaultInteractableRoutine
 [Properties]: #Properties
 [ActivationArea]: #ActivationArea
 [ActivationValidator]: #ActivationValidator
+[AllValidRules]: #AllValidRules
 [CollidingObjectsList]: #CollidingObjectsList
 [DestinationLocation]: #DestinationLocation
 [Facade]: #Facade
 [ForceUnsnapInteractableProcess]: #ForceUnsnapInteractableProcess
 [GrabStateEmitter]: #GrabStateEmitter
+[InitialTransitionDuration]: #InitialTransitionDuration
 [PropertyApplier]: #PropertyApplier
 [SnapDroppedInteractableProcess]: #SnapDroppedInteractableProcess
 [SnappableInteractables]: #SnappableInteractables
@@ -403,4 +473,5 @@ public virtual void Unsnap()
 [OnEnable()]: #OnEnable
 [ProcessOtherSnappablesOnSnap()]: #ProcessOtherSnappablesOnSnap
 [Snap(GameObject)]: #SnapGameObject
+[SnapInitialAtEndOfFrame()]: #SnapInitialAtEndOfFrame
 [Unsnap()]: #Unsnap

--- a/Documentation/API/SnapZoneFacade.md
+++ b/Documentation/API/SnapZoneFacade.md
@@ -16,6 +16,7 @@ The public interface into the Interactions SnapZone Prefab.
   * [Unsnapped]
 * [Properties]
   * [Configuration]
+  * [InitialSnappedInteractable]
   * [SnappableGameObjects]
   * [SnappedGameObject]
   * [SnapValidity]
@@ -117,6 +118,16 @@ The linked Configurator Setup.
 
 ```
 public SnapZoneConfigurator Configuration { get; protected set; }
+```
+
+#### InitialSnappedInteractable
+
+An optional InteractableFacade to snap into the snap zone when the snap zone is enabled.
+
+##### Declaration
+
+```
+public InteractableFacade InitialSnappedInteractable { get; set; }
 ```
 
 #### SnappableGameObjects
@@ -251,6 +262,7 @@ public virtual void Unsnap()
 [Unsnapped]: #Unsnapped
 [Properties]: #Properties
 [Configuration]: #Configuration
+[InitialSnappedInteractable]: #InitialSnappedInteractable
 [SnappableGameObjects]: #SnappableGameObjects
 [SnappedGameObject]: #SnappedGameObject
 [SnapValidity]: #SnapValidity

--- a/Documentation/API/SnapZoneManager.md
+++ b/Documentation/API/SnapZoneManager.md
@@ -1,0 +1,103 @@
+# Class SnapZoneManager
+
+A helper class for managing scene snap zones.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [IsInSnapZone(InteractableFacade)]
+  * [IsInSnapZone(InteractableFacade, out SnapZoneFacade)]
+  * [UnsnapInteractable(InteractableFacade)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* SnapZoneManager
+
+##### Namespace
+
+* [Tilia.Interactions.SnapZone]
+
+##### Syntax
+
+```
+public class SnapZoneManager : MonoBehaviour
+```
+
+### Methods
+
+#### IsInSnapZone(InteractableFacade)
+
+Determines if the given Interactable is in a Snap Zone.
+
+##### Declaration
+
+```
+public virtual bool IsInSnapZone(InteractableFacade interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| InteractableFacade | interactable | The Interactable to search on. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the given Interactable is in a Snap Zone. |
+
+#### IsInSnapZone(InteractableFacade, out SnapZoneFacade)
+
+Determines if the given Interactable is in a Snap Zone and optionally returns the Snap Zone if it is one.
+
+##### Declaration
+
+```
+public virtual bool IsInSnapZone(InteractableFacade interactable, out SnapZoneFacade snapZoneFacade)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| InteractableFacade | interactable | The Interactable to search on. |
+| [SnapZoneFacade] | snapZoneFacade | The found Snap Zone to return. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the given Interactable is in a Snap Zone. |
+
+#### UnsnapInteractable(InteractableFacade)
+
+Attempts to unsnap the given Interactable if it is snapped into a snap zone.
+
+##### Declaration
+
+```
+public virtual void UnsnapInteractable(InteractableFacade interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| InteractableFacade | interactable | The Interactable to attempt to unsnap. |
+
+[Tilia.Interactions.SnapZone]: README.md
+[SnapZoneFacade]: SnapZoneFacade.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[IsInSnapZone(InteractableFacade)]: #IsInSnapZoneInteractableFacade
+[IsInSnapZone(InteractableFacade, out SnapZoneFacade)]: #IsInSnapZoneInteractableFacade-out SnapZoneFacade
+[UnsnapInteractable(InteractableFacade)]: #UnsnapInteractableInteractableFacade

--- a/Documentation/API/SnapZoneManager.md.meta
+++ b/Documentation/API/SnapZoneManager.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9f36ea1a59fcfcd43827c39effb012d1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
@@ -55,6 +55,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public float TransitionDuration { get; set; }
+        /// <summary>
+        /// An optional <see cref="InteractableFacade"/> to snap into the snap zone when the snap zone is enabled.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public InteractableFacade InitialSnappedInteractable { get; set; }
         #endregion
 
         #region Reference Settings


### PR DESCRIPTION
The new InitialSnappedInteractable property allows for an Interactable
to be specified that will be snapped to the zone (if the rules permit
it) when the snap zone is enabled.