### PR TITLE
feat(Prefabs): add auto snap thrown objects option

### DIFF
--- a/Documentation/API/SnapZoneConfigurator.md
+++ b/Documentation/API/SnapZoneConfigurator.md
@@ -14,6 +14,7 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [ActivationArea]
   * [ActivationValidator]
   * [AllValidRules]
+  * [AutoSnapLogicContainer]
   * [CollidingObjectsList]
   * [DestinationLocation]
   * [Facade]
@@ -28,6 +29,7 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [ValidCollisionRules]
   * [ValidSnappableInteractablesList]
 * [Methods]
+  * [ConfigureAutoSnap()]
   * [ConfigurePropertyApplier()]
   * [ConfigureValidityRules()]
   * [EmitActivated(GameObject)]
@@ -112,6 +114,16 @@ The AllRule that takes the [ValidCollisionRules].
 
 ```
 public AllRule AllValidRules { get; protected set; }
+```
+
+#### AutoSnapLogicContainer
+
+The GameObject that contains the auto snap logic.
+
+##### Declaration
+
+```
+public GameObject AutoSnapLogicContainer { get; protected set; }
 ```
 
 #### CollidingObjectsList
@@ -245,6 +257,16 @@ public GameObjectObservableList ValidSnappableInteractablesList { get; protected
 ```
 
 ### Methods
+
+#### ConfigureAutoSnap()
+
+Configures the auto snap logic.
+
+##### Declaration
+
+```
+public virtual void ConfigureAutoSnap()
+```
 
 #### ConfigurePropertyApplier()
 
@@ -447,6 +469,7 @@ public virtual void Unsnap()
 [ActivationArea]: #ActivationArea
 [ActivationValidator]: #ActivationValidator
 [AllValidRules]: #AllValidRules
+[AutoSnapLogicContainer]: #AutoSnapLogicContainer
 [CollidingObjectsList]: #CollidingObjectsList
 [DestinationLocation]: #DestinationLocation
 [Facade]: #Facade
@@ -461,6 +484,7 @@ public virtual void Unsnap()
 [ValidCollisionRules]: #ValidCollisionRules
 [ValidSnappableInteractablesList]: #ValidSnappableInteractablesList
 [Methods]: #Methods
+[ConfigureAutoSnap()]: #ConfigureAutoSnap
 [ConfigurePropertyApplier()]: #ConfigurePropertyApplier
 [ConfigureValidityRules()]: #ConfigureValidityRules
 [EmitActivated(GameObject)]: #EmitActivatedGameObject

--- a/Documentation/API/SnapZoneFacade.md
+++ b/Documentation/API/SnapZoneFacade.md
@@ -15,6 +15,7 @@ The public interface into the Interactions SnapZone Prefab.
   * [Snapped]
   * [Unsnapped]
 * [Properties]
+  * [AutoSnapThrownObjects]
   * [Configuration]
   * [InitialSnappedInteractable]
   * [SnappableGameObjects]
@@ -23,6 +24,7 @@ The public interface into the Interactions SnapZone Prefab.
   * [TransitionDuration]
   * [ZoneState]
 * [Methods]
+  * [OnAfterAutoSnapThrownObjectsChange()]
   * [OnAfterSnapValidityChange()]
   * [OnAfterTransitionDurationChange()]
   * [Snap(GameObject)]
@@ -110,6 +112,16 @@ public SnapZoneFacade.UnityEvent Unsnapped
 
 ### Properties
 
+#### AutoSnapThrownObjects
+
+Whether to auto snap a thrown GameObject into this snap zone even if the GameObject is not being held as it enters the collision area.
+
+##### Declaration
+
+```
+public bool AutoSnapThrownObjects { get; set; }
+```
+
 #### Configuration
 
 The linked Configurator Setup.
@@ -182,6 +194,16 @@ public SnapZoneFacade.SnapZoneState ZoneState { get; }
 
 ### Methods
 
+#### OnAfterAutoSnapThrownObjectsChange()
+
+Called after [AutoSnapThrownObjects] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterAutoSnapThrownObjectsChange()
+```
+
 #### OnAfterSnapValidityChange()
 
 Called after [SnapValidity] has been changed.
@@ -248,6 +270,7 @@ public virtual void Unsnap()
 [SnapZoneFacade.UnityEvent]: SnapZoneFacade.UnityEvent.md
 [SnapZoneConfigurator]: SnapZoneConfigurator.md
 [SnapZoneFacade.SnapZoneState]: SnapZoneFacade.SnapZoneState.md
+[AutoSnapThrownObjects]: SnapZoneFacade.md#AutoSnapThrownObjects
 [SnapValidity]: SnapZoneFacade.md#SnapValidity
 [TransitionDuration]: SnapZoneFacade.md#TransitionDuration
 [Inheritance]: #Inheritance
@@ -261,6 +284,7 @@ public virtual void Unsnap()
 [Snapped]: #Snapped
 [Unsnapped]: #Unsnapped
 [Properties]: #Properties
+[AutoSnapThrownObjects]: #AutoSnapThrownObjects
 [Configuration]: #Configuration
 [InitialSnappedInteractable]: #InitialSnappedInteractable
 [SnappableGameObjects]: #SnappableGameObjects
@@ -269,6 +293,7 @@ public virtual void Unsnap()
 [TransitionDuration]: #TransitionDuration
 [ZoneState]: #ZoneState
 [Methods]: #Methods
+[OnAfterAutoSnapThrownObjectsChange()]: #OnAfterAutoSnapThrownObjectsChange
 [OnAfterSnapValidityChange()]: #OnAfterSnapValidityChange
 [OnAfterTransitionDurationChange()]: #OnAfterTransitionDurationChange
 [Snap(GameObject)]: #SnapGameObject

--- a/Runtime/Prefabs/Interactions.SnapZone.prefab
+++ b/Runtime/Prefabs/Interactions.SnapZone.prefab
@@ -94,6 +94,66 @@ MonoBehaviour:
   source:
     transform: {fileID: 0}
     useLocalValues: 0
+--- !u!1 &5185142757575960199
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7466983072290418195}
+  - component: {fileID: 5826042504852474404}
+  m_Layer: 0
+  m_Name: AutoSnapLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7466983072290418195
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5185142757575960199}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8407923665345995131}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5826042504852474404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5185142757575960199}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09ae85fc95510224291abaade783b420, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  payload: {fileID: 0}
+  Emitted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8407923665924606686}
+        m_MethodName: Snap
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  receiveValidity:
+    field: {fileID: 0}
 --- !u!1 &5760640743601652393
 GameObject:
   m_ObjectHideFlags: 0
@@ -2017,6 +2077,7 @@ MonoBehaviour:
     field: {fileID: 0}
   containingTransformValidity:
     field: {fileID: 0}
+  stayDelayInterval: 0
 --- !u!114 &8407923664845045257
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3186,6 +3247,7 @@ Transform:
   - {fileID: 8407923664551792854}
   - {fileID: 8407923665421349808}
   - {fileID: 8407923664475317335}
+  - {fileID: 7466983072290418195}
   m_Father: {fileID: 8407923664618568645}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3315,7 +3377,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3327,7 +3388,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4626,6 +4686,7 @@ MonoBehaviour:
     field: {fileID: 0}
   transitionDuration: 0
   initialSnappedInteractable: {fileID: 0}
+  autoSnapThrownObjects: 0
   configuration: {fileID: 8407923666110382458}
   Entered:
     m_PersistentCalls:
@@ -4720,6 +4781,17 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 8407923664475317334}
         m_MethodName: RegisterGrabbed
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5826042504852474404}
+        m_MethodName: Receive
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -5306,6 +5378,7 @@ MonoBehaviour:
   snapDroppedInteractableProcess: {fileID: 8407923664943525174}
   forceUnsnapInteractableProcess: {fileID: 8407923664429067986}
   destinationLocation: {fileID: 8407923664650951421}
+  autoSnapLogicContainer: {fileID: 5185142757575960199}
   initialTransitionDuration: 0
 --- !u!1 &8407923666129015629
 GameObject:

--- a/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
@@ -103,6 +103,12 @@
         [field: DocumentedByXml, Restricted]
         public GameObject DestinationLocation { get; protected set; }
         /// <summary>
+        /// The <see cref="GameObject"/> that contains the auto snap logic.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, Restricted]
+        public GameObject AutoSnapLogicContainer { get; protected set; }
+        /// <summary>
         /// The initial duration to transition the default Interactable to the SnapZone.
         /// </summary>
         [Serialized]
@@ -292,6 +298,14 @@
         }
 
         /// <summary>
+        /// Configures the auto snap logic.
+        /// </summary>
+        public virtual void ConfigureAutoSnap()
+        {
+            AutoSnapLogicContainer.SetActive(Facade.AutoSnapThrownObjects);
+        }
+
+        /// <summary>
         /// Attempts to process any other valid snappable objects against any other potential SnapZones if their primary activating zone is snapped by another object.
         /// </summary>
         public virtual void ProcessOtherSnappablesOnSnap()
@@ -329,6 +343,7 @@
         {
             ConfigureValidityRules();
             ConfigurePropertyApplier();
+            ConfigureAutoSnap();
             SnapDefaultInteractableRoutine = StartCoroutine(SnapInitialAtEndOfFrame());
 
             if (SnappedInteractable != null)

--- a/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
@@ -61,6 +61,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public InteractableFacade InitialSnappedInteractable { get; set; }
+        /// <summary>
+        /// Whether to auto snap a thrown <see cref="GameObject"/> into this snap zone even if the <see cref="GameObject"/> is not being held as it enters the collision area.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public bool AutoSnapThrownObjects { get; set; }
         #endregion
 
         #region Reference Settings
@@ -175,6 +181,15 @@
         protected virtual void OnAfterTransitionDurationChange()
         {
             Configuration.ConfigurePropertyApplier();
+        }
+
+        /// <summary>
+        /// Called after <see cref="AutoSnapThrownObjects"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(AutoSnapThrownObjects))]
+        protected virtual void OnAfterAutoSnapThrownObjectsChange()
+        {
+            Configuration.ConfigureAutoSnap();
         }
     }
 }


### PR DESCRIPTION
The new Auto Snap Thrown Objects option allows an object to auto snap
to a snap zone as soon as the valid object enters it even if the object
is not being held at the point of entering.