### PR TITLE
fix(Configurator): ensure prepare kinematic change is called everywhere - fixes #191

### DIFF
--- a/Runtime/Prefabs/Interactions.SnapZone.prefab
+++ b/Runtime/Prefabs/Interactions.SnapZone.prefab
@@ -332,6 +332,17 @@ MonoBehaviour:
   Emitted:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 8407923666110382458}
+        m_MethodName: PrepareKinematicStateChange
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
       - m_Target: {fileID: 8407923666089960734}
         m_MethodName: set_IsKinematic
         m_Mode: 6

--- a/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
@@ -333,6 +333,35 @@
         }
 
         /// <summary>
+        /// Prepares the given <see cref="InteractableFacade"/> for a kinematic state change.
+        /// </summary>
+        /// <param name="target">The interactable to prepare.</param>
+        public virtual void PrepareKinematicStateChange(InteractableFacade target)
+        {
+            if(target == null)
+            {
+                return;
+            }
+
+            PrepareKinematicStateChange(target.Configuration.ConsumerRigidbody);
+        }
+
+        /// <summary>
+        /// Prepares the given <see cref="GameObject"/> for a kinematic state change.
+        /// </summary>
+        /// <param name="target">The GameObject to prepare.</param>
+        public virtual void PrepareKinematicStateChange(GameObject target)
+        {
+            InteractableFacade interactable = target.TryGetComponent<InteractableFacade>(true, true);
+            if (interactable == null)
+            {
+                return;
+            }
+
+            PrepareKinematicStateChange(interactable.Configuration.ConsumerRigidbody);
+        }
+
+        /// <summary>
         /// Attempts to snap a given <see cref="GameObject"/> to the snap zone.
         /// </summary>
         /// <param name="objectToSnap">The object to attempt to snap.</param>


### PR DESCRIPTION
The PrepareKinematicStateChange mechanism was only being called when
the Interactable was directly placed within the snap zone, if it was
dropped from above and the auto snap was on then the logic would never
be called and therefore the double exit/enter would occur.

This fixes it by providing more methods for preparing the state change
with different object types just for completeness and then the prefab
now ensures before the rigidbody state is changed on the interactable
that it prepares the collider tracker for this state change.