### PR TITLE
feat(Facade): add option for highlight always on and scale optional

### DIFF
--- a/Documentation/API/SnapZoneConfigurator.md
+++ b/Documentation/API/SnapZoneConfigurator.md
@@ -18,8 +18,11 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [CollidingObjectsList]
   * [DestinationLocation]
   * [Facade]
+  * [Follower]
   * [ForceUnsnapInteractableProcess]
   * [GrabStateEmitter]
+  * [HighlightLogicContainer]
+  * [HighlightMeshContainer]
   * [InitialTransitionDuration]
   * [PropertyApplier]
   * [SnapDroppedInteractableProcess]
@@ -30,7 +33,9 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [ValidSnappableInteractablesList]
 * [Methods]
   * [ConfigureAutoSnap()]
+  * [ConfigureHighlightLogic()]
   * [ConfigurePropertyApplier()]
+  * [ConfigureSnapZoneScaling()]
   * [ConfigureValidityRules()]
   * [EmitActivated(GameObject)]
   * [EmitDeactivated(GameObject)]
@@ -40,6 +45,8 @@ Sets up the Interactions SnapZone Prefab based on the provided user settings.
   * [EmitUnsnapped(GameObject)]
   * [OnDisable()]
   * [OnEnable()]
+  * [PrepareKinematicStateChange(GameObject)]
+  * [PrepareKinematicStateChange(InteractableFacade)]
   * [PrepareKinematicStateChange(Rigidbody)]
   * [ProcessOtherSnappablesOnSnap()]
   * [Snap(GameObject)]
@@ -94,7 +101,7 @@ The [SnapZoneActivator] that determines if the activation area.
 ##### Declaration
 
 ```
-public SnapZoneActivator ActivationArea { get; protected set; }
+public SnapZoneActivator ActivationArea { get; set; }
 ```
 
 #### ActivationValidator
@@ -104,7 +111,7 @@ The [ActivationValidator] that determines if the activation of the zone is valid
 ##### Declaration
 
 ```
-public ActivationValidator ActivationValidator { get; protected set; }
+public ActivationValidator ActivationValidator { get; set; }
 ```
 
 #### AllValidRules
@@ -114,7 +121,7 @@ The AllRule that takes the [ValidCollisionRules].
 ##### Declaration
 
 ```
-public AllRule AllValidRules { get; protected set; }
+public AllRule AllValidRules { get; set; }
 ```
 
 #### AutoSnapLogicContainer
@@ -124,7 +131,7 @@ The GameObject that contains the auto snap logic.
 ##### Declaration
 
 ```
-public GameObject AutoSnapLogicContainer { get; protected set; }
+public GameObject AutoSnapLogicContainer { get; set; }
 ```
 
 #### CollidingObjectsList
@@ -134,7 +141,7 @@ The GameObjectObservableList containing the list of objects that are currently c
 ##### Declaration
 
 ```
-public GameObjectObservableList CollidingObjectsList { get; protected set; }
+public GameObjectObservableList CollidingObjectsList { get; set; }
 ```
 
 #### DestinationLocation
@@ -144,7 +151,7 @@ The GameObject that determines the snap destination location.
 ##### Declaration
 
 ```
-public GameObject DestinationLocation { get; protected set; }
+public GameObject DestinationLocation { get; set; }
 ```
 
 #### Facade
@@ -154,7 +161,17 @@ The public interface facade.
 ##### Declaration
 
 ```
-public SnapZoneFacade Facade { get; protected set; }
+public SnapZoneFacade Facade { get; set; }
+```
+
+#### Follower
+
+The GameObject that holds the highlight on hover logic.
+
+##### Declaration
+
+```
+public ObjectFollower Follower { get; set; }
 ```
 
 #### ForceUnsnapInteractableProcess
@@ -164,7 +181,7 @@ The GameObjectEventProxyEmitter that is responsible for forcing an unsnap of the
 ##### Declaration
 
 ```
-public GameObjectEventProxyEmitter ForceUnsnapInteractableProcess { get; protected set; }
+public GameObjectEventProxyEmitter ForceUnsnapInteractableProcess { get; set; }
 ```
 
 #### GrabStateEmitter
@@ -174,7 +191,27 @@ The InteractableGrabStateEmitter that processes if the interactable entering the
 ##### Declaration
 
 ```
-public InteractableGrabStateEmitter GrabStateEmitter { get; protected set; }
+public InteractableGrabStateEmitter GrabStateEmitter { get; set; }
+```
+
+#### HighlightLogicContainer
+
+The GameObject that holds the highlight on hover logic.
+
+##### Declaration
+
+```
+public GameObject HighlightLogicContainer { get; set; }
+```
+
+#### HighlightMeshContainer
+
+The GameObject that holds the highlight mesh containerc.
+
+##### Declaration
+
+```
+public GameObject HighlightMeshContainer { get; set; }
 ```
 
 #### InitialTransitionDuration
@@ -194,7 +231,7 @@ The TransformPropertyApplier that transitions the Interactable to the snapped de
 ##### Declaration
 
 ```
-public TransformPropertyApplier PropertyApplier { get; protected set; }
+public TransformPropertyApplier PropertyApplier { get; set; }
 ```
 
 #### SnapDroppedInteractableProcess
@@ -204,7 +241,7 @@ The GameObjectEventProxyEmitter that is responsible for processing the snap of a
 ##### Declaration
 
 ```
-public GameObjectEventProxyEmitter SnapDroppedInteractableProcess { get; protected set; }
+public GameObjectEventProxyEmitter SnapDroppedInteractableProcess { get; set; }
 ```
 
 #### SnappableInteractables
@@ -234,7 +271,7 @@ The GameObjectObservableList containing the list of snapped Interactables.
 ##### Declaration
 
 ```
-public GameObjectObservableList SnappedInteractablesList { get; protected set; }
+public GameObjectObservableList SnappedInteractablesList { get; set; }
 ```
 
 #### ValidCollisionRules
@@ -244,7 +281,7 @@ The RuleContainerObservableList that determines the valid snappable Interactable
 ##### Declaration
 
 ```
-public RuleContainerObservableList ValidCollisionRules { get; protected set; }
+public RuleContainerObservableList ValidCollisionRules { get; set; }
 ```
 
 #### ValidSnappableInteractablesList
@@ -254,7 +291,7 @@ The GameObjectObservableList containing the list of Interactables that can be sn
 ##### Declaration
 
 ```
-public GameObjectObservableList ValidSnappableInteractablesList { get; protected set; }
+public GameObjectObservableList ValidSnappableInteractablesList { get; set; }
 ```
 
 ### Methods
@@ -269,6 +306,16 @@ Configures the auto snap logic.
 public virtual void ConfigureAutoSnap()
 ```
 
+#### ConfigureHighlightLogic()
+
+Configures the highlight logic of the snap zone.
+
+##### Declaration
+
+```
+public virtual void ConfigureHighlightLogic()
+```
+
 #### ConfigurePropertyApplier()
 
 Configures the transition duration for the snapping process.
@@ -277,6 +324,16 @@ Configures the transition duration for the snapping process.
 
 ```
 public virtual void ConfigurePropertyApplier()
+```
+
+#### ConfigureSnapZoneScaling()
+
+Configures whether the snap zone will scale the target snapped object.
+
+##### Declaration
+
+```
+public virtual void ConfigureSnapZoneScaling()
 ```
 
 #### ConfigureValidityRules()
@@ -401,6 +458,38 @@ protected virtual void OnDisable()
 protected virtual void OnEnable()
 ```
 
+#### PrepareKinematicStateChange(GameObject)
+
+Prepares the given GameObject for a kinematic state change.
+
+##### Declaration
+
+```
+public virtual void PrepareKinematicStateChange(GameObject target)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | target | The GameObject to prepare. |
+
+#### PrepareKinematicStateChange(InteractableFacade)
+
+Prepares the given InteractableFacade for a kinematic state change.
+
+##### Declaration
+
+```
+public virtual void PrepareKinematicStateChange(InteractableFacade target)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| InteractableFacade | target | The interactable to prepare. |
+
 #### PrepareKinematicStateChange(Rigidbody)
 
 Prepares the given Rigidbody for a kinematic state change.
@@ -489,8 +578,11 @@ public virtual void Unsnap()
 [CollidingObjectsList]: #CollidingObjectsList
 [DestinationLocation]: #DestinationLocation
 [Facade]: #Facade
+[Follower]: #Follower
 [ForceUnsnapInteractableProcess]: #ForceUnsnapInteractableProcess
 [GrabStateEmitter]: #GrabStateEmitter
+[HighlightLogicContainer]: #HighlightLogicContainer
+[HighlightMeshContainer]: #HighlightMeshContainer
 [InitialTransitionDuration]: #InitialTransitionDuration
 [PropertyApplier]: #PropertyApplier
 [SnapDroppedInteractableProcess]: #SnapDroppedInteractableProcess
@@ -501,7 +593,9 @@ public virtual void Unsnap()
 [ValidSnappableInteractablesList]: #ValidSnappableInteractablesList
 [Methods]: #Methods
 [ConfigureAutoSnap()]: #ConfigureAutoSnap
+[ConfigureHighlightLogic()]: #ConfigureHighlightLogic
 [ConfigurePropertyApplier()]: #ConfigurePropertyApplier
+[ConfigureSnapZoneScaling()]: #ConfigureSnapZoneScaling
 [ConfigureValidityRules()]: #ConfigureValidityRules
 [EmitActivated(GameObject)]: #EmitActivatedGameObject
 [EmitDeactivated(GameObject)]: #EmitDeactivatedGameObject
@@ -511,6 +605,8 @@ public virtual void Unsnap()
 [EmitUnsnapped(GameObject)]: #EmitUnsnappedGameObject
 [OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
+[PrepareKinematicStateChange(GameObject)]: #PrepareKinematicStateChangeGameObject
+[PrepareKinematicStateChange(InteractableFacade)]: #PrepareKinematicStateChangeInteractableFacade
 [PrepareKinematicStateChange(Rigidbody)]: #PrepareKinematicStateChangeRigidbody
 [ProcessOtherSnappablesOnSnap()]: #ProcessOtherSnappablesOnSnap
 [Snap(GameObject)]: #SnapGameObject

--- a/Documentation/API/SnapZoneFacade.md
+++ b/Documentation/API/SnapZoneFacade.md
@@ -15,8 +15,10 @@ The public interface into the Interactions SnapZone Prefab.
   * [Snapped]
   * [Unsnapped]
 * [Properties]
+  * [ApplySnapZoneScale]
   * [AutoSnapThrownObjects]
   * [Configuration]
+  * [HighlightAlwaysActive]
   * [InitialSnappedInteractable]
   * [SnappableGameObjects]
   * [SnappedGameObject]
@@ -26,7 +28,9 @@ The public interface into the Interactions SnapZone Prefab.
 * [Methods]
   * [AllowSnappedObjectGrab()]
   * [ClearSnapValidity()]
+  * [OnAfterApplySnapZoneScaleChange()]
   * [OnAfterAutoSnapThrownObjectsChange()]
+  * [OnAfterHighlightAlwaysActiveChange()]
   * [OnAfterSnapValidityChange()]
   * [OnAfterTransitionDurationChange()]
   * [PreventSnappedObjectGrab()]
@@ -116,6 +120,16 @@ public SnapZoneFacade.UnityEvent Unsnapped
 
 ### Properties
 
+#### ApplySnapZoneScale
+
+Whether to apply the scale of the snap zone to the target that is snapped into it.
+
+##### Declaration
+
+```
+public bool ApplySnapZoneScale { get; set; }
+```
+
 #### AutoSnapThrownObjects
 
 Whether to auto snap a thrown GameObject into this snap zone even if the GameObject is not being held as it enters the collision area.
@@ -133,7 +147,17 @@ The linked Configurator Setup.
 ##### Declaration
 
 ```
-public SnapZoneConfigurator Configuration { get; protected set; }
+public SnapZoneConfigurator Configuration { get; set; }
+```
+
+#### HighlightAlwaysActive
+
+Whether the snap zone highlight is always active or only active when the snap zone is actively hovered in.
+
+##### Declaration
+
+```
+public bool HighlightAlwaysActive { get; set; }
 ```
 
 #### InitialSnappedInteractable
@@ -218,6 +242,16 @@ Clears [SnapValidity].
 public virtual void ClearSnapValidity()
 ```
 
+#### OnAfterApplySnapZoneScaleChange()
+
+Called after [ApplySnapZoneScale] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterApplySnapZoneScaleChange()
+```
+
 #### OnAfterAutoSnapThrownObjectsChange()
 
 Called after [AutoSnapThrownObjects] has been changed.
@@ -226,6 +260,16 @@ Called after [AutoSnapThrownObjects] has been changed.
 
 ```
 protected virtual void OnAfterAutoSnapThrownObjectsChange()
+```
+
+#### OnAfterHighlightAlwaysActiveChange()
+
+Called after [HighlightAlwaysActive] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterHighlightAlwaysActiveChange()
 ```
 
 #### OnAfterSnapValidityChange()
@@ -321,7 +365,9 @@ public virtual void Unsnap()
 [SnapZoneConfigurator]: SnapZoneConfigurator.md
 [SnapZoneFacade.SnapZoneState]: SnapZoneFacade.SnapZoneState.md
 [SnapValidity]: SnapZoneFacade.md#SnapValidity
+[ApplySnapZoneScale]: SnapZoneFacade.md#ApplySnapZoneScale
 [AutoSnapThrownObjects]: SnapZoneFacade.md#AutoSnapThrownObjects
+[HighlightAlwaysActive]: SnapZoneFacade.md#HighlightAlwaysActive
 [SnapValidity]: SnapZoneFacade.md#SnapValidity
 [TransitionDuration]: SnapZoneFacade.md#TransitionDuration
 [Inheritance]: #Inheritance
@@ -335,8 +381,10 @@ public virtual void Unsnap()
 [Snapped]: #Snapped
 [Unsnapped]: #Unsnapped
 [Properties]: #Properties
+[ApplySnapZoneScale]: #ApplySnapZoneScale
 [AutoSnapThrownObjects]: #AutoSnapThrownObjects
 [Configuration]: #Configuration
+[HighlightAlwaysActive]: #HighlightAlwaysActive
 [InitialSnappedInteractable]: #InitialSnappedInteractable
 [SnappableGameObjects]: #SnappableGameObjects
 [SnappedGameObject]: #SnappedGameObject
@@ -346,7 +394,9 @@ public virtual void Unsnap()
 [Methods]: #Methods
 [AllowSnappedObjectGrab()]: #AllowSnappedObjectGrab
 [ClearSnapValidity()]: #ClearSnapValidity
+[OnAfterApplySnapZoneScaleChange()]: #OnAfterApplySnapZoneScaleChange
 [OnAfterAutoSnapThrownObjectsChange()]: #OnAfterAutoSnapThrownObjectsChange
+[OnAfterHighlightAlwaysActiveChange()]: #OnAfterHighlightAlwaysActiveChange
 [OnAfterSnapValidityChange()]: #OnAfterSnapValidityChange
 [OnAfterTransitionDurationChange()]: #OnAfterTransitionDurationChange
 [PreventSnappedObjectGrab()]: #PreventSnappedObjectGrab

--- a/Runtime/Prefabs/Interactions.SnapZone.prefab
+++ b/Runtime/Prefabs/Interactions.SnapZone.prefab
@@ -2046,7 +2046,7 @@ SphereCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 1.5
+  m_Radius: 1
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &8407923664845045255
 MonoBehaviour:
@@ -2204,6 +2204,7 @@ MonoBehaviour:
     forwardSource: {fileID: 0}
     isTrigger: 0
     colliderData: {fileID: 0}
+  extractCompoundParent: 1
 --- !u!1 &8407923664929508104
 GameObject:
   m_ObjectHideFlags: 0
@@ -3448,7 +3449,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: e1802e4f7b45aca4e979a361bc7edcfe, type: 2}
+  - {fileID: 2100000, guid: cac370e18424aeb40b14e48b6086e96c, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3484,7 +3485,7 @@ MonoBehaviour:
   pipelines:
   - pipelineName: (?i)default
     materials:
-    - {fileID: 2100000, guid: e1802e4f7b45aca4e979a361bc7edcfe, type: 2}
+    - {fileID: 2100000, guid: cac370e18424aeb40b14e48b6086e96c, type: 2}
   - pipelineName: (?i)urp
     materials:
     - {fileID: 2100000, guid: cac370e18424aeb40b14e48b6086e96c, type: 2}
@@ -3904,6 +3905,7 @@ MonoBehaviour:
     forwardSource: {fileID: 0}
     isTrigger: 0
     colliderData: {fileID: 0}
+  extractCompoundParent: 1
 --- !u!1 &8407923665507313185
 GameObject:
   m_ObjectHideFlags: 0
@@ -4833,6 +4835,8 @@ MonoBehaviour:
     field: {fileID: 0}
   transitionDuration: 0
   initialSnappedInteractable: {fileID: 0}
+  highlightAlwaysActive: 0
+  applySnapZoneScale: 1
   autoSnapThrownObjects: 0
   configuration: {fileID: 8407923666110382458}
   Entered:
@@ -5524,6 +5528,9 @@ MonoBehaviour:
   snappedInteractablesList: {fileID: 8407923665559923119}
   snapDroppedInteractableProcess: {fileID: 8407923664943525174}
   forceUnsnapInteractableProcess: {fileID: 8407923664429067986}
+  highlightMeshContainer: {fileID: 8407923664662382997}
+  highlightLogicContainer: {fileID: 8407923664967594663}
+  follower: {fileID: 5740525694681145957}
   destinationLocation: {fileID: 8407923664650951421}
   autoSnapLogicContainer: {fileID: 5185142757575960199}
   initialTransitionDuration: 0
@@ -5811,6 +5818,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5634598753569639371}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5740525694681145957 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114960550120155566, guid: 9aa99d00578590e45a52faa205a1014a,
+    type: 3}
+  m_PrefabInstance: {fileID: 5634598753569639371}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &6730208074106967650 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1392910959889882537, guid: 9aa99d00578590e45a52faa205a1014a,

--- a/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneConfigurator.cs
@@ -6,11 +6,13 @@
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Collection.List;
+    using Zinnia.Data.Enum;
     using Zinnia.Data.Type;
     using Zinnia.Event.Proxy;
     using Zinnia.Extension;
     using Zinnia.Rule;
     using Zinnia.Rule.Collection;
+    using Zinnia.Tracking.Follow;
     using Zinnia.Tracking.Modification;
 
     /// <summary>
@@ -33,7 +35,7 @@
             {
                 return facade;
             }
-            protected set
+            set
             {
                 facade = value;
             }
@@ -55,7 +57,7 @@
             {
                 return validCollisionRules;
             }
-            protected set
+            set
             {
                 validCollisionRules = value;
             }
@@ -73,7 +75,7 @@
             {
                 return allValidRules;
             }
-            protected set
+            set
             {
                 allValidRules = value;
             }
@@ -91,7 +93,7 @@
             {
                 return grabStateEmitter;
             }
-            protected set
+            set
             {
                 grabStateEmitter = value;
             }
@@ -109,7 +111,7 @@
             {
                 return activationArea;
             }
-            protected set
+            set
             {
                 activationArea = value;
             }
@@ -127,7 +129,7 @@
             {
                 return activationValidator;
             }
-            protected set
+            set
             {
                 activationValidator = value;
             }
@@ -145,7 +147,7 @@
             {
                 return propertyApplier;
             }
-            protected set
+            set
             {
                 propertyApplier = value;
             }
@@ -163,7 +165,7 @@
             {
                 return collidingObjectsList;
             }
-            protected set
+            set
             {
                 collidingObjectsList = value;
             }
@@ -181,7 +183,7 @@
             {
                 return validSnappableInteractablesList;
             }
-            protected set
+            set
             {
                 validSnappableInteractablesList = value;
             }
@@ -199,7 +201,7 @@
             {
                 return snappedInteractablesList;
             }
-            protected set
+            set
             {
                 snappedInteractablesList = value;
             }
@@ -217,7 +219,7 @@
             {
                 return snapDroppedInteractableProcess;
             }
-            protected set
+            set
             {
                 snapDroppedInteractableProcess = value;
             }
@@ -235,9 +237,63 @@
             {
                 return forceUnsnapInteractableProcess;
             }
-            protected set
+            set
             {
                 forceUnsnapInteractableProcess = value;
+            }
+        }
+        [Tooltip("The GameObject that holds the highlight mesh container.")]
+        [SerializeField]
+        [Restricted]
+        private GameObject highlightMeshContainer;
+        /// <summary>
+        /// The <see cref="GameObject"/> that holds the highlight mesh containerc.
+        /// </summary>
+        public GameObject HighlightMeshContainer
+        {
+            get
+            {
+                return highlightMeshContainer;
+            }
+            set
+            {
+                highlightMeshContainer = value;
+            }
+        }
+        [Tooltip("The GameObject that holds the highlight on hover logic.")]
+        [SerializeField]
+        [Restricted]
+        private GameObject highlightLogicContainer;
+        /// <summary>
+        /// The <see cref="GameObject"/> that holds the highlight on hover logic.
+        /// </summary>
+        public GameObject HighlightLogicContainer
+        {
+            get
+            {
+                return highlightLogicContainer;
+            }
+            set
+            {
+                highlightLogicContainer = value;
+            }
+        }
+        [Tooltip("The GameObject that holds the highlight on hover logic.")]
+        [SerializeField]
+        [Restricted]
+        private ObjectFollower follower;
+        /// <summary>
+        /// The <see cref="GameObject"/> that holds the highlight on hover logic.
+        /// </summary>
+        public ObjectFollower Follower
+        {
+            get
+            {
+                return follower;
+            }
+            set
+            {
+                follower = value;
             }
         }
         [Tooltip("The GameObject that determines the snap destination location.")]
@@ -253,7 +309,7 @@
             {
                 return destinationLocation;
             }
-            protected set
+            set
             {
                 destinationLocation = value;
             }
@@ -271,7 +327,7 @@
             {
                 return autoSnapLogicContainer;
             }
-            protected set
+            set
             {
                 autoSnapLogicContainer = value;
             }
@@ -338,7 +394,7 @@
         /// <param name="target">The interactable to prepare.</param>
         public virtual void PrepareKinematicStateChange(InteractableFacade target)
         {
-            if(target == null)
+            if (target == null)
             {
                 return;
             }
@@ -520,6 +576,27 @@
         }
 
         /// <summary>
+        /// Configures the highlight logic of the snap zone.
+        /// </summary>
+        public virtual void ConfigureHighlightLogic()
+        {
+            HighlightLogicContainer.SetActive(!Facade.HighlightAlwaysActive);
+            if (Facade.HighlightAlwaysActive && SnappedInteractable == null)
+            {
+                HighlightMeshContainer.SetActive(true);
+            }
+        }
+
+        /// <summary>
+        /// Configures whether the snap zone will scale the target snapped object.
+        /// </summary>
+        public virtual void ConfigureSnapZoneScaling()
+        {
+            Follower.FollowModifier.ScaleModifier.gameObject.SetActive(Facade.ApplySnapZoneScale);
+            propertyApplier.ApplyTransformations = Facade.ApplySnapZoneScale ? (TransformProperties)(-1) : TransformProperties.Position | TransformProperties.Rotation;
+        }
+
+        /// <summary>
         /// Configures the auto snap logic.
         /// </summary>
         public virtual void ConfigureAutoSnap()
@@ -565,6 +642,8 @@
         {
             ConfigureValidityRules();
             ConfigurePropertyApplier();
+            ConfigureHighlightLogic();
+            ConfigureSnapZoneScaling();
             ConfigureAutoSnap();
             SnapDefaultInteractableRoutine = StartCoroutine(SnapInitialAtEndOfFrame());
 

--- a/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
@@ -100,6 +100,48 @@
                 initialSnappedInteractable = value;
             }
         }
+        [Tooltip("Whether to apply the scale of the snap zone to the target that is snapped into it.")]
+        [SerializeField]
+        private bool applySnapZoneScale = true;
+        /// <summary>
+        /// Whether to apply the scale of the snap zone to the target that is snapped into it.
+        /// </summary>
+        public bool ApplySnapZoneScale
+        {
+            get
+            {
+                return applySnapZoneScale;
+            }
+            set
+            {
+                applySnapZoneScale = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterApplySnapZoneScaleChange();
+                }
+            }
+        }
+        [Tooltip("Whether the snap zone highlight is always active or only active when the snap zone is actively hovered in.")]
+        [SerializeField]
+        private bool highlightAlwaysActive;
+        /// <summary>
+        /// Whether the snap zone highlight is always active or only active when the snap zone is actively hovered in.
+        /// </summary>
+        public bool HighlightAlwaysActive
+        {
+            get
+            {
+                return highlightAlwaysActive;
+            }
+            set
+            {
+                highlightAlwaysActive = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterHighlightAlwaysActiveChange();
+                }
+            }
+        }
         [Tooltip("Whether to auto snap a thrown GameObject into this snap zone even if the GameObject is not being held as it enters the collision area.")]
         [SerializeField]
         private bool autoSnapThrownObjects;
@@ -138,7 +180,7 @@
             {
                 return configuration;
             }
-            protected set
+            set
             {
                 configuration = value;
             }
@@ -298,6 +340,22 @@
         protected virtual void OnAfterTransitionDurationChange()
         {
             Configuration.ConfigurePropertyApplier();
+        }
+
+        /// <summary>
+        /// Called after <see cref="HighlightAlwaysActive"/> has been changed.
+        /// </summary>
+        protected virtual void OnAfterHighlightAlwaysActiveChange()
+        {
+            Configuration.ConfigureHighlightLogic();
+        }
+
+        /// <summary>
+        /// Called after <see cref="ApplySnapZoneScale"/> has been changed.
+        /// </summary>
+        protected virtual void OnAfterApplySnapZoneScaleChange()
+        {
+            Configuration.ConfigureSnapZoneScaling();
         }
 
         /// <summary>


### PR DESCRIPTION
The Facade now has the ability to set the highlight object as always on when the snap zone is not being used or hovered over. There is also another option that allows the scaling properties of the snap zone to be optional so it doesnt change the size of the snapped object upon being snapped to the zone.