### PR TITLE
fix(Facade): toggle isVisible correctly

### DIFF
--- a/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
+++ b/Runtime/SharedResources/Scripts/SnapZoneFacade.cs
@@ -253,13 +253,13 @@
             }
             set
             {
-                if (gameObject.activeInHierarchy)
+                if (value)
                 {
-                    Configuration.Hide();
+                    Configuration.Show();
                 }
                 else
                 {
-                    Configuration.Show();
+                    Configuration.Hide();
                 }
             }
         }


### PR DESCRIPTION
The IsVisible property was not actually toggling correctly as if `=false` was passed twice, then the second time it would actually show the snap zone rather than simply continue to hide it.